### PR TITLE
Feature/shared page

### DIFF
--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -26,6 +26,10 @@ class AppThemeNotifier extends Notifier<ThemeData> {
           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         ),
       ),
+      iconTheme: IconThemeData(
+        color: customThemeColors.buttonPrimary,
+        size: 24,
+      ),
     );
   }
 }

--- a/lib/utils/custom_theme_colors.dart
+++ b/lib/utils/custom_theme_colors.dart
@@ -25,6 +25,8 @@ class CustomThemeColors {
       isDarkMode ? CustomColors.dark.gray50 : CustomColors.white;
   Color get backgroundLabel =>
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray100;
+  Color get backgroundSurface =>
+      isDarkMode ? CustomColors.dark.gray50 : CustomColors.light.gray100;
 
   Color get surface =>
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.white;
@@ -49,6 +51,8 @@ class CustomThemeColors {
 
   Color get strokeDivider =>
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray200;
+  Color get strokeBorder =>
+      isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray900;
 
   Color get red => isDarkMode ? CustomColors.dark.red : CustomColors.light.red;
   Color get blue =>

--- a/lib/utils/custom_theme_colors.dart
+++ b/lib/utils/custom_theme_colors.dart
@@ -23,6 +23,8 @@ class CustomThemeColors {
       isDarkMode ? CustomColors.dark.gray900 : CustomColors.light.gray900;
   Color get backgroundElevated =>
       isDarkMode ? CustomColors.dark.gray50 : CustomColors.white;
+  Color get backgroundLabel =>
+      isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray100;
 
   Color get surface =>
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.white;

--- a/lib/utils/custom_theme_colors.dart
+++ b/lib/utils/custom_theme_colors.dart
@@ -27,6 +27,8 @@ class CustomThemeColors {
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray100;
   Color get backgroundSurface =>
       isDarkMode ? CustomColors.dark.gray50 : CustomColors.light.gray100;
+  Color get backgroundPath =>
+      isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray200;
 
   Color get surface =>
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.white;
@@ -41,6 +43,8 @@ class CustomThemeColors {
       isDarkMode ? CustomColors.dark.gray100 : CustomColors.light.gray400;
   Color get textInvert =>
       isDarkMode ? CustomColors.dark.gray50 : CustomColors.light.gray50;
+  Color get textTertiary =>
+      isDarkMode ? CustomColors.dark.gray300 : CustomColors.light.gray300;
 
   Color get buttonPrimary =>
       isDarkMode ? CustomColors.dark.gray900 : CustomColors.light.gray900;

--- a/lib/views/setting_screen/setting_drawer.dart
+++ b/lib/views/setting_screen/setting_drawer.dart
@@ -26,6 +26,7 @@ class SettingDrawer extends ConsumerWidget {
     final customTextStyle = ref.watch(customTextStyleProvider);
 
     return MainWrapper(
+      padding: const EdgeInsets.all(16),
       appBar: const CommonAppBar(
         title: '설정',
       ),

--- a/lib/views/shared_tab/shared_card.dart
+++ b/lib/views/shared_tab/shared_card.dart
@@ -37,7 +37,7 @@ class SharedCard extends ConsumerWidget {
 
     return Container(
       padding:
-          const EdgeInsets.only(top: 8.0, left: 16.0, right: 8.0, bottom: 8.0),
+          const EdgeInsets.only(left: 16.0, top: 8.0, right: 8.0, bottom: 8.0),
       constraints: const BoxConstraints(maxHeight: 232),
       decoration: BoxDecoration(
         color: customThemeColors.background,
@@ -95,27 +95,31 @@ class SharedCard extends ConsumerWidget {
               },
             ),
           ),
-          const Gap(8),
           Expanded(
-            child: RichText(
-              overflow: TextOverflow.ellipsis,
-              maxLines: 6,
-              text: TextSpan(
-                children: [
-                  TextSpan(
-                    text: content,
-                    style: customTextStyle.bodySmall,
-                  ),
-                ],
+            child: Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: RichText(
+                overflow: TextOverflow.ellipsis,
+                maxLines: 6,
+                text: TextSpan(
+                  children: [
+                    TextSpan(
+                      text: content,
+                      style: customTextStyle.bodySmall,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
+          const Gap(8),
           const CommonRowWithDivider(
             tail: CommonIconButton(
-                icon: Icon(
-              CustomIcons.heart_line,
-            )),
-          )
+              icon: Icon(
+                CustomIcons.heart_line,
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/views/shared_tab/shared_card.dart
+++ b/lib/views/shared_tab/shared_card.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:four_hours_client/utils/custom_icons_icons.dart';
+import 'package:four_hours_client/utils/custom_shadow_colors.dart';
+import 'package:four_hours_client/utils/custom_text_style.dart';
+import 'package:four_hours_client/utils/custom_theme_colors.dart';
+import 'package:four_hours_client/views/widgets/common_icon_button.dart';
+import 'package:four_hours_client/views/widgets/common_row_with_divider.dart';
+import 'package:four_hours_client/views/widgets/gap.dart';
+
+class SharedCard extends ConsumerWidget {
+  final String labelText;
+  final String content;
+  const SharedCard({
+    Key? key,
+    required this.labelText,
+    required this.content,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final customTextStyle = ref.watch(customTextStyleProvider);
+    final customThemeColors = ref.watch(customThemeColorsProvider);
+
+    return Container(
+      padding:
+          const EdgeInsets.only(top: 8.0, left: 16.0, right: 8.0, bottom: 8.0),
+      constraints: const BoxConstraints(maxHeight: 232),
+      decoration: BoxDecoration(
+        color: customThemeColors.background,
+        borderRadius: BorderRadius.circular(12.0),
+        boxShadow: CustomShadowColors.shadow3,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CommonRowWithDivider(
+            header: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2.0),
+              decoration: BoxDecoration(
+                color: customThemeColors.backgroundLabel,
+                borderRadius: BorderRadius.circular(4.0),
+              ),
+              child: Text(
+                labelText,
+                style: customTextStyle.montLabelSmall,
+              ),
+            ),
+            rightGap: 8,
+            tail: const CommonIconButton(
+              icon: Icon(
+                CustomIcons.more_line,
+              ),
+            ),
+          ),
+          const Gap(8),
+          Expanded(
+            child: RichText(
+              overflow: TextOverflow.ellipsis,
+              maxLines: 6,
+              text: TextSpan(
+                children: [
+                  TextSpan(
+                    text: content,
+                    style: customTextStyle.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const CommonRowWithDivider(
+            tail: CommonIconButton(
+                icon: Icon(
+              CustomIcons.heart_line,
+            )),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/shared_tab/shared_card.dart
+++ b/lib/views/shared_tab/shared_card.dart
@@ -4,6 +4,10 @@ import 'package:four_hours_client/utils/custom_icons_icons.dart';
 import 'package:four_hours_client/utils/custom_shadow_colors.dart';
 import 'package:four_hours_client/utils/custom_text_style.dart';
 import 'package:four_hours_client/utils/custom_theme_colors.dart';
+import 'package:four_hours_client/utils/functions.dart';
+import 'package:four_hours_client/views/shared_tab/shared_page_provider.dart';
+import 'package:four_hours_client/views/widgets/common_action_sheet_action.dart';
+import 'package:four_hours_client/views/widgets/common_card_cover.dart';
 import 'package:four_hours_client/views/widgets/common_icon_button.dart';
 import 'package:four_hours_client/views/widgets/common_row_with_divider.dart';
 import 'package:four_hours_client/views/widgets/gap.dart';
@@ -21,6 +25,15 @@ class SharedCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final customTextStyle = ref.watch(customTextStyleProvider);
     final customThemeColors = ref.watch(customThemeColorsProvider);
+    final isReported = ref.watch(sharedReportNotifierProvider);
+
+    if (isReported) {
+      return const CommonCardCover(
+        iconData: CustomIcons.report_fill,
+        title: '신고가 정상적으로 접수되었어요',
+        subtitle: '해당 글은 숨긴처리 됐습니다',
+      );
+    }
 
     return Container(
       padding:
@@ -48,10 +61,38 @@ class SharedCard extends ConsumerWidget {
               ),
             ),
             rightGap: 8,
-            tail: const CommonIconButton(
-              icon: Icon(
+            tail: CommonIconButton(
+              icon: const Icon(
                 CustomIcons.more_line,
               ),
+              onTap: () {
+                showCommonActionSheet(
+                  context,
+                  actions: [
+                    CommonActionSheetAction(
+                      isDestructiveAction: true,
+                      onPressed: () {
+                        closeRootNavigator(context);
+                        showCommonDialogWithTwoButtons(
+                          context,
+                          iconData: CustomIcons.report_fill,
+                          title: '해당 게시글을 신고하시겠어요?',
+                          subtitle: '신고가 접수되면 즉시 사라집니다',
+                          onPressedRightButton: () {
+                            ref
+                                .read(sharedReportNotifierProvider.notifier)
+                                .reportWriting();
+                            closeRootNavigator(context);
+                          },
+                          rightButtonText: '신고',
+                        );
+                      },
+                      iconData: CustomIcons.report_line,
+                      text: '게시글 신고',
+                    )
+                  ],
+                );
+              },
             ),
           ),
           const Gap(8),

--- a/lib/views/shared_tab/shared_page.dart
+++ b/lib/views/shared_tab/shared_page.dart
@@ -1,15 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:four_hours_client/views/shared_tab/shared_card.dart';
 
-class SharedPage extends StatelessWidget {
+final Map fakeCardData = {
+  'time': DateTime.now().hour,
+  'content':
+      '오늘은 예보와는 달리 비가 오지 않았고, 구름이 가득하며 하늘이 흐린 날씨였다. 그래도 나는 이런 흐린 날씨가 어색하게 느껴지지 않았다.  언젠가 창밖을 내다보며 세상을 감상하고 있을 때, 하늘이 완벽한 파란색으로 빛나고 나무들은 바람에 가볍게 흔들리며 모든 것이 살아있는 것 같아 마음이 설레였다. 이러한 순간들은 인생의 경이롭고 아름다움에 대해 깊은 감사를 느끼게 만들어준다. 오늘은 예보와는 달리 비가 오지 않았고, 구름이 가득하며 하늘이 흐린 날씨였다. 그래도 나는 이런 흐린 날씨가 어색하게 느껴지지 않았다.  언젠가 창밖을 내다보며 세상을 감상하고 있을 때, 하늘이 완벽한 파란색으로 빛나고 나무들은 바람에 가볍게 흔들리며 모든 것이 살아있는 것 같아 마음이 설레였다. 이러한 순간들은 인생의 경이롭고 아름다움에 대해 깊은 감사를 느끼게 만들어준다.',
+};
+
+class SharedPage extends ConsumerWidget {
   const SharedPage({Key? key}) : super(key: key);
   static const String path = '/shared';
 
   @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Text(
-        'Shared Page',
-        style: TextStyle(fontSize: 30, color: Colors.white),
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: ListView.separated(
+        itemBuilder: (context, index) {
+          return Padding(
+            padding:
+                const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+            child: SharedCard(
+              labelText: '${fakeCardData['time']}hours',
+              content: fakeCardData['content'],
+            ),
+          );
+        },
+        separatorBuilder: (context, index) =>
+            SizedBox.fromSize(size: const Size(0, 0)),
+        itemCount: 12,
       ),
     );
   }

--- a/lib/views/shared_tab/shared_page_provider.dart
+++ b/lib/views/shared_tab/shared_page_provider.dart
@@ -1,0 +1,17 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+class SharedReportNotifier extends AutoDisposeNotifier<bool> {
+  @override
+  bool build() {
+    state = false;
+    return state;
+  }
+
+  void reportWriting() {
+    state = true;
+  }
+}
+
+final sharedReportNotifierProvider =
+    AutoDisposeNotifierProvider<SharedReportNotifier, bool>(
+        SharedReportNotifier.new);

--- a/lib/views/widgets/common_action_sheet_action.dart
+++ b/lib/views/widgets/common_action_sheet_action.dart
@@ -10,6 +10,7 @@ class CommonActionSheetAction extends ConsumerWidget {
   final Color? color;
   final Color? backgroundColor;
   final VoidCallback onPressed;
+  final bool isDestructiveAction;
   const CommonActionSheetAction({
     Key? key,
     required this.onPressed,
@@ -17,6 +18,7 @@ class CommonActionSheetAction extends ConsumerWidget {
     required this.text,
     this.color,
     this.backgroundColor,
+    this.isDestructiveAction = false,
   }) : super(key: key);
 
   @override
@@ -36,13 +38,18 @@ class CommonActionSheetAction extends ConsumerWidget {
             Icon(
               iconData,
               size: 24,
-              color: color ?? customThemeColors.textPrimary,
+              color: isDestructiveAction
+                  ? customThemeColors.red
+                  : color ?? customThemeColors.textPrimary,
             ),
             const Gap(8),
             Text(
               text,
-              style: customTextStyle.titleMedium
-                  .copyWith(color: color ?? customThemeColors.textPrimary),
+              style: customTextStyle.titleMedium.copyWith(
+                color: isDestructiveAction
+                    ? customThemeColors.red
+                    : color ?? customThemeColors.textPrimary,
+              ),
             )
           ],
         ),

--- a/lib/views/widgets/common_card_cover.dart
+++ b/lib/views/widgets/common_card_cover.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:four_hours_client/utils/custom_shadow_colors.dart';
+import 'package:four_hours_client/utils/custom_text_style.dart';
+import 'package:four_hours_client/utils/custom_theme_colors.dart';
+import 'package:four_hours_client/views/widgets/gap.dart';
+
+class CommonCardCover extends ConsumerWidget {
+  final IconData iconData;
+  final String title;
+  final String subtitle;
+  const CommonCardCover({
+    Key? key,
+    required this.iconData,
+    required this.title,
+    required this.subtitle,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final customTextStyle = ref.watch(customTextStyleProvider);
+    final customThemeColors = ref.watch(customThemeColorsProvider);
+
+    return Container(
+      height: 232,
+      decoration: BoxDecoration(
+        color: customThemeColors.backgroundSurface,
+        border: Border.all(
+          width: 2,
+          color: customThemeColors.strokeBorder,
+        ),
+        borderRadius: BorderRadius.circular(12.0),
+        boxShadow: CustomShadowColors.shadow3,
+      ),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              iconData,
+              size: 32,
+            ),
+            const Gap(8),
+            Text(
+              title,
+              style: customTextStyle.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+            const Gap(4),
+            Text(
+              subtitle,
+              style: customTextStyle.bodySmall.copyWith(
+                color: customThemeColors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/common_dialog_with_two_buttons.dart
+++ b/lib/views/widgets/common_dialog_with_two_buttons.dart
@@ -68,12 +68,8 @@ class CommonDialogWithTwoButtons extends ConsumerWidget {
                     },
                     style: TextButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 13),
-                      backgroundColor: Colors.transparent,
+                      backgroundColor: customThemeColors.buttonDisabled,
                       foregroundColor: customThemeColors.textPrimary,
-                      side: BorderSide(
-                        width: 1,
-                        color: customThemeColors.buttonPrimary,
-                      ),
                     ),
                     child: Text(
                       leftButtonText ?? '취소',

--- a/lib/views/widgets/common_row_with_divider.dart
+++ b/lib/views/widgets/common_row_with_divider.dart
@@ -6,22 +6,26 @@ import 'package:four_hours_client/views/widgets/gap.dart';
 class CommonRowWithDivider extends ConsumerWidget {
   final Widget? header;
   final Widget? tail;
+  final double leftGap;
+  final double rightGap;
   const CommonRowWithDivider({
     Key? key,
     this.header,
     this.tail,
+    this.leftGap = 16,
+    this.rightGap = 16,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     List<Widget> renderHeader() {
       return header != null
-          ? [header!, const Gap(16)]
+          ? [header!, Gap(leftGap)]
           : [const SizedBox.shrink()];
     }
 
     List<Widget> renderTail() {
-      return tail != null ? [const Gap(16), tail!] : [const SizedBox.shrink()];
+      return tail != null ? [Gap(rightGap), tail!] : [const SizedBox.shrink()];
     }
 
     return Row(

--- a/lib/views/widgets/common_widgets_page.dart
+++ b/lib/views/widgets/common_widgets_page.dart
@@ -26,8 +26,7 @@ class CommonWidgetsPage extends ConsumerWidget {
                 context,
                 actions: [
                   CommonActionSheetAction(
-                    color: customThemeColors.red,
-                    backgroundColor: customThemeColors.background,
+                    isDestructiveAction: true,
                     onPressed: () {},
                     iconData: CustomIcons.delete_bin_line,
                     text: '게시글 삭제',

--- a/lib/views/widgets/main_wrapper.dart
+++ b/lib/views/widgets/main_wrapper.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:four_hours_client/constants/app_sizes.dart';
 import 'package:four_hours_client/utils/custom_theme_colors.dart';
 import 'package:four_hours_client/views/setting_screen/setting_drawer.dart';
 
@@ -11,7 +10,7 @@ class MainWrapper extends ConsumerWidget {
   const MainWrapper({
     Key? key,
     required this.child,
-    this.padding = const EdgeInsets.all(pagePadding),
+    this.padding = EdgeInsets.zero,
     this.appBar,
   }) : super(key: key);
 
@@ -23,7 +22,10 @@ class MainWrapper extends ConsumerWidget {
       appBar: appBar,
       backgroundColor: customThemeColors.background,
       body: SafeArea(
-        child: child,
+        child: Padding(
+          padding: padding,
+          child: child,
+        ),
       ),
       endDrawer: const SettingDrawer(),
     );

--- a/lib/views/widgets/main_wrapper.dart
+++ b/lib/views/widgets/main_wrapper.dart
@@ -23,10 +23,7 @@ class MainWrapper extends ConsumerWidget {
       appBar: appBar,
       backgroundColor: customThemeColors.background,
       body: SafeArea(
-        child: Padding(
-          padding: padding,
-          child: child,
-        ),
+        child: child,
       ),
       endDrawer: const SettingDrawer(),
     );

--- a/lib/views/write_tab/write_page.dart
+++ b/lib/views/write_tab/write_page.dart
@@ -9,7 +9,6 @@ import 'package:four_hours_client/views/widgets/common_full_width_text_button.da
 import 'package:four_hours_client/views/widgets/common_row_with_divider.dart';
 import 'package:four_hours_client/views/widgets/common_title.dart';
 import 'package:four_hours_client/views/widgets/gap.dart';
-import 'package:four_hours_client/views/widgets/main_wrapper.dart';
 import 'package:go_router/go_router.dart';
 
 class WritePage extends ConsumerWidget {
@@ -18,7 +17,8 @@ class WritePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return MainWrapper(
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
       child: Center(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -43,37 +43,36 @@ class Card extends ConsumerWidget {
     final customTextStyle = ref.watch(customTextStyleProvider);
 
     return Container(
+      padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
-          color: CustomColors.white,
-          borderRadius: BorderRadius.circular(12.0),
-          boxShadow: CustomShadowColors.shadow1),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            CommonRowWithDivider(
-              header: Center(
-                child: Text(
-                  '오늘의 주제: 변화',
-                  style: customTextStyle.titleSmall,
-                ),
+        color: CustomColors.white,
+        borderRadius: BorderRadius.circular(12.0),
+        boxShadow: CustomShadowColors.shadow1,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CommonRowWithDivider(
+            header: Center(
+              child: Text(
+                '오늘의 주제: 변화',
+                style: customTextStyle.titleSmall,
               ),
             ),
-            const Gap(10),
-            Text(
-              '날씨가 점점 봄으로 바뀌고 있다.\n 그 변화를 느끼며, 기분도 따뜻해지고 있다.',
-              style: customTextStyle.bodySmall
-                  .copyWith(color: CustomColors.light.gray400),
-            ),
-            const Gap(16),
-            CommonFullWidthTextButton(
-                onPressed: () {
-                  context.push('${WritePage.path}/${CreateWritingPage.path}');
-                },
-                text: '글 쓰기')
-          ],
-        ),
+          ),
+          const Gap(10),
+          Text(
+            '날씨가 점점 봄으로 바뀌고 있다.\n 그 변화를 느끼며, 기분도 따뜻해지고 있다.',
+            style: customTextStyle.bodySmall
+                .copyWith(color: CustomColors.light.gray400),
+          ),
+          const Gap(16),
+          CommonFullWidthTextButton(
+              onPressed: () {
+                context.push('${WritePage.path}/${CreateWritingPage.path}');
+              },
+              text: '글 쓰기')
+        ],
       ),
     );
   }

--- a/lib/views/write_tab/write_page.dart
+++ b/lib/views/write_tab/write_page.dart
@@ -5,6 +5,7 @@ import 'package:four_hours_client/utils/custom_icons_icons.dart';
 import 'package:four_hours_client/utils/custom_shadow_colors.dart';
 import 'package:four_hours_client/utils/custom_text_style.dart';
 import 'package:four_hours_client/views/create_writing_screen/create_writing_page.dart';
+import 'package:four_hours_client/views/widgets/common_card_cover.dart';
 import 'package:four_hours_client/views/widgets/common_full_width_text_button.dart';
 import 'package:four_hours_client/views/widgets/common_row_with_divider.dart';
 import 'package:four_hours_client/views/widgets/common_title.dart';
@@ -19,7 +20,7 @@ class WritePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: Center(
+      child: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: const [
@@ -27,7 +28,11 @@ class WritePage extends ConsumerWidget {
             Gap(8),
             Card(),
             Gap(16),
-            TryYourFirstWritingCard()
+            CommonCardCover(
+              iconData: CustomIcons.pencil_fill,
+              title: '첫 게시글을 작성해보세요!',
+              subtitle: '순간의 일과 감정들을 글로 적어보면,\n그것들을 더 잘 이해하고 조절할 수 있어요.',
+            )
           ],
         ),
       ),


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->
## Checklist
- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?
- [x] **Rebase:** (필요시) rebase를 완료했나요?
- [ ] **Conflict Resolution:** 충돌을 해결하는 과정을 거쳤나요?
- [ ] **New Dependencies:** 새로운 dependency를 추가했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->
## Description
shared page의 기본적인 ui작업

신고했을 때 바뀌는 UI가 공통으로 적용되는 곳이 많아 공통 위젯으로 변경


<!-- List all the changes that were made in this pull request --> 
## Changes Made
- lib/utils/app_theme.dart: 기본적인 icon theme 추가
- lib/utils/custom_theme_colors.dart: 필요한 색상 추가
- lib/views/shared_tab/shared_card.dart: shared page에서 사용할 공통 카드 위젯 추가
- lib/views/shared_tab/shared_page.dart: shared card 적용
- lib/views/shared_tab/shared_page_provider.dart: 신고 로직 추가
- lib/views/widgets/common_action_sheet_action.dart: 중요한 행위를 할 때 색을 하나하나 바꾸지 않고 isDestructiveAction 속성 하나로 적용
- lib/views/widgets/common_card_cover.dart: 공통으로 사용할 카드 커버 추가
- lib/views/widgets/common_row_with_divider.dart: tail에 icon button이 자주 들어가는데 icon button은 패딩 8을 가지고 있어 패딩을 조정할 필요가 있어 속성 추가
- lib/views/widgets/main_wrapper.dart: write page나 shared page에서 기본적으로 패딩 16을 주고 시작하면 shadow가 잘리는 현상 발생 -> 기본을 zero 패딩을 주고 페이지에 맞는 패딩을 주도록 변경

<!-- If applicable, add screenshots to help explain your changes -->
## Screenshots


https://user-images.githubusercontent.com/76954805/233919180-3608fbb2-db88-4f9d-8331-c0ee7537f39e.mov



## Extra Comments
